### PR TITLE
Use real Druid URL

### DIFF
--- a/config_example.yaml
+++ b/config_example.yaml
@@ -1,7 +1,7 @@
 druid:
   # Set bypass_proxy to true to bypass system-configured proxy, for WMF SWAP/Jupyter setup.
   bypass_proxy: true
-  url: "protocol://host:port"
+  url: "http://druid1001.eqiad.wmnet:8082"
   endpoint: "druid/v2"
 
 # Config to translate from CN project to WMF production project, as it appears in the


### PR DESCRIPTION
It seems more useful to include a live URL, even if it might go out
of date.  This is public info available on pages such as,
https://wikitech.wikimedia.org/wiki/Analytics/Systems/Druid